### PR TITLE
Let the router handle the routing.

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,7 +9,7 @@ import fetch from 'isomorphic-fetch';
 import dataUrls from '../static/dataUrls.json';
 
 export const SET_STATE = 'SET_STATE';
-export const MODE_CHANGED = 'MODE_CHANGED';
+// export const MODE_CHANGED = 'MODE_CHANGED';
 export const MAP_MOVED = 'MAP_MOVED';
 export const MAP_LAYERS_PICKER_LAYERS_CHANGED = 'MAP_LAYERS_PICKER_LAYERS_CHANGED';
 export const MAP_LAYERS_PICKER_TRANSPORTATION_CHANGED = 'MAP_LAYERS_PICKER_TRANSPORTATION_CHANGED';
@@ -56,6 +56,7 @@ export default function (store) {
 			});
 		},
 
+		/*
 		modeChanged (value) {
 			// Only allow map or page modes
 			value = (value in ['map', 'page'] ? value : 'page');
@@ -64,6 +65,7 @@ export default function (store) {
 				value: value
 			});
 		},
+		*/
 
 		mapMoved (mapState) {
 			store.dispatch({

--- a/src/components/MapPageToggle.js
+++ b/src/components/MapPageToggle.js
@@ -1,32 +1,32 @@
 import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
 
-const MapPageToggle = ({mode, modeChanged}) => {
+const MapPageToggle = ({ mode, currentLocation }) => {
 
-	function mapClicked () {
-		modeChanged('map');
-	}
+	// e.g. http://some-server.com/#/stories/page/joe-biden-washes-his-transam
+	let path = currentLocation.pathname.split('/'),
+		view = path.length > 1 ? path[1] : '',
+		// mode = path.length > 2 ? path[2] : '',
+		other = path.length > 3 ? path.slice(3).join('/') : '';
 
-	function pageClicked () {
-		modeChanged('page');
-	}
+	let mapUrl = view ? `${ view }/map/${ other }` : `map`,
+		pageUrl = view ? `${ view }/page/${ other }` : `page`;
 
 	return (
-		<div className="map-page-toggle">
-			<div className={"map-page-toggle-btn" + (mode === 'map' ? ' active' : '')} onClick={(() => mapClicked())}>
-				map
-				<span className="map-page-toggle-btn-fulltext"> view</span>
-			</div>
-			<div className={"map-page-toggle-btn" + (mode === 'page' ? ' active' : '')} onClick={(() => pageClicked())}>
-				page
-				<span className="map-page-toggle-btn-fulltext"> view</span>
-			</div>
+		<div className='map-page-toggle'>
+			<Link to={ mapUrl } className={ 'map-page-toggle-btn' + (mode === 'map' ? ' active' : '') }>
+				map<span className='map-page-toggle-btn-fulltext'> view</span>
+			</Link>
+			<Link to={ pageUrl } className={ 'map-page-toggle-btn' + (mode === 'page' ? ' active' : '') }>
+				page<span className='map-page-toggle-btn-fulltext'> view</span>
+			</Link>
 		</div>
 	);
 };
 
 MapPageToggle.propTypes = {
 	mode: PropTypes.string,
-	modeChanged: PropTypes.func
+	currentLocation: PropTypes.object
 };
 
 export default MapPageToggle;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -69,9 +69,8 @@ render((
 
 			<Route path='stories'>
 				<IndexRedirect to='page' />
-				<Route path=':mode' component={ Stories }>
-					<Route path=':title' component={ Story } />
-				</Route>
+				<Route path=':mode' component={ Stories } />
+				<Route path=':mode/:title' component={ Story } />
 			</Route>
 
 			<Route path='events'>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -81,7 +81,8 @@ render((
 			<Route path='projects'>
 				<IndexRedirect to='page' />
 				<Route path=':mode' component={ Projects } />
-				<Route path=':mode/:zone' component={ Zone } />
+				<Route path='page/:zone' component={ Zone } />
+				<Route path='map/:zone' component={ Projects } />
 			</Route>
 
 			<Route path='about'>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -61,19 +61,34 @@ const createReduxComponent = (Component, props) => {
 render((
 	<Router history={ appHistory } createElement={ createReduxComponent }>
 		<Route path='/' component={ App }>
-			<IndexRoute component={ Home } />
-			<Route path='stories' component={ Stories } />
-			<Route path='stories/:mode' component={ Stories } />
-			<Route path='stories/:mode/:title' component={ Story } />
-			<Route path='events' component={ Events } />
-			<Route path='events/:mode' component={ Events } />
+			<IndexRedirect to='home' />
+			<Route path='home'>
+				<IndexRedirect to='page' />
+				<Route path=':mode' component={ Home } />
+			</Route>
+
+			<Route path='stories'>
+				<IndexRedirect to='page' />
+				<Route path=':mode' component={ Stories }>
+					<Route path=':title' component={ Story } />
+				</Route>
+			</Route>
+
+			<Route path='events'>
+				<IndexRedirect to='page' />
+				<Route path=':mode' component={ Events } />
+			</Route>
+
 			<Route path='projects'>
 				<IndexRedirect to='page' />
 				<Route path=':mode' component={ Projects } />
 				<Route path=':mode/:zone' component={ Zone } />
 			</Route>
-			<Route path='about' component={ About } />
-			<Route path='about/:mode' component={ About } />
+
+			<Route path='about'>
+				<IndexRedirect to='page' />
+				<Route path=':mode' component={ About } />
+			</Route>
 		</Route>
 		<Route path='*' component={ RouteNotFound } />
 	</Router>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,12 +4,12 @@ import { applyMiddleware, createStore, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
 import { Redirect,
-  Router,
-  Route,
-  IndexRedirect,
-  IndexRoute,
-  useRouterHistory,
-  hashHistory } from 'react-router';
+	Router,
+	Route,
+	IndexRedirect,
+	IndexRoute,
+	useRouterHistory,
+	hashHistory } from 'react-router';
 import { createHashHistory } from 'history';
 
 import App from './views/App.jsx';
@@ -28,8 +28,8 @@ import actionCreator from './actions';
 const middleware = [thunkMiddleware];
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
-  // redux-logger only works in a browser environment
-  // middleware.push(createLogger());
+	// redux-logger only works in a browser environment
+	// middleware.push(createLogger());
 }
 
 // Create the single store for this application session
@@ -67,9 +67,11 @@ render((
 			<Route path='stories/:mode/:title' component={ Story } />
 			<Route path='events' component={ Events } />
 			<Route path='events/:mode' component={ Events } />
-			<Route path='projects' component={ Projects } />
-			<Route path='projects/:mode' component={ Projects } />
-			<Route path='projects/:mode/:zone' component={ Zone } />
+			<Route path='projects'>
+				<IndexRedirect to='page' />
+				<Route path=':mode' component={ Projects } />
+				<Route path=':mode/:zone' component={ Zone } />
+			</Route>
 			<Route path='about' component={ About } />
 			<Route path='about/:mode' component={ About } />
 		</Route>

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -25,6 +25,7 @@ const MAP_LAYERS_PICKER_DEFAULT_PROJECTS = false;
 
 export default {
 
+	/*
 	mode (state = 'page', action) {
 		switch (action.type) {
 			case actions.MODE_CHANGED:
@@ -33,6 +34,7 @@ export default {
 				return state;
 		}
 	},
+	*/
 
 	map (state = {}, action) {
 		switch (action.type) {
@@ -360,8 +362,6 @@ export default {
 // These values will override the defaults specified in each reducer's argument list,
 // and can be merged into a set of initial state on store init if desired.
 export const initialState = {
-
-	mode: 'page',
 
 	map: {
 		zoom: 14,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -6,22 +6,6 @@ import { cleanEventsData } from './models/events';
 import { cleanStoriesData } from './models/stories';
 import { cleanProjectsData } from './models/projects';
 
-// TODO: these consts should move into initialState (bottom of this file)
-const MAP_LAYERS_PICKER_DEFAULT_LAYERS = [
-	{ key: 'boat_landings', name: 'boat landings / launches', checked: false},
-	{ key: 'picnic_tables', name: 'picnic tables', checked: false },
-	{ key: 'benches', name: 'benches', checked: false },
-	{ key: 'community gardens', name: 'community gardens', checked: false },
-	{ key: 'development pipeline', name: 'development pipeline', checked: false }
-];
-const MAP_LAYERS_PICKER_DEFAULT_TRANSPORTATION = [
-	{ key: 'walking_biking', name: 'walking / biking', checked: true },
-	{ key: 'connector_streets', name: 'connector streets / paths', checked: false },
-	{ key: 'green_connector_network', name: 'green connector network', checked: false },
-	{ key: 'public_transportation', name: 'public transportation', checked: false }
-];
-const MAP_LAYERS_PICKER_DEFAULT_PROJECTS = false;
-
 export default {
 
 	/*
@@ -50,7 +34,7 @@ export default {
 	},
 
 	mapLayersPicker: combineReducers({
-		layers (state = MAP_LAYERS_PICKER_DEFAULT_LAYERS, action) {
+		layers (state = {}, action) {
 			switch (action.type) {
 				case actions.MAP_LAYERS_PICKER_LAYERS_CHANGED:
 					return state.map(layer => {
@@ -64,7 +48,7 @@ export default {
 			}
 		},
 
-		transportation (state = MAP_LAYERS_PICKER_DEFAULT_TRANSPORTATION, action) {
+		transportation (state = {}, action) {
 			switch (action.type) {
 				case actions.MAP_LAYERS_PICKER_TRANSPORTATION_CHANGED:
 					return state.map(layer => {
@@ -78,7 +62,7 @@ export default {
 			}
 		},
 
-		projects (state = MAP_LAYERS_PICKER_DEFAULT_PROJECTS, action) {
+		projects (state = {}, action) {
 			switch (action.type) {
 				case actions.MAP_LAYERS_PICKER_PROJECTS_CHANGED:
 					return action.value;
@@ -345,6 +329,23 @@ export const initialState = {
 		scrollWheelZoom: false,
 		doubleClickZoom: false,
 		boxZoom: false
+	},
+
+	mapLayersPicker: {
+		layers: [
+			{ key: 'boat_landings', name: 'boat landings / launches', checked: false},
+			{ key: 'picnic_tables', name: 'picnic tables', checked: false },
+			{ key: 'benches', name: 'benches', checked: false },
+			{ key: 'community gardens', name: 'community gardens', checked: false },
+			{ key: 'development pipeline', name: 'development pipeline', checked: false }
+		],
+		transportation: [
+			{ key: 'walking_biking', name: 'walking / biking', checked: true },
+			{ key: 'connector_streets', name: 'connector streets / paths', checked: false },
+			{ key: 'green_connector_network', name: 'green connector network', checked: false },
+			{ key: 'public_transportation', name: 'public transportation', checked: false }
+		],
+		projects: false
 	},
 
 	events: {

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -6,8 +6,7 @@ import { cleanEventsData } from './models/events';
 import { cleanStoriesData } from './models/stories';
 import { cleanProjectsData } from './models/projects';
 
-// const identity = (state, action) => state;
-
+// TODO: these consts should move into initialState (bottom of this file)
 const MAP_LAYERS_PICKER_DEFAULT_LAYERS = [
 	{ key: 'boat_landings', name: 'boat landings / launches', checked: false},
 	{ key: 'picnic_tables', name: 'picnic tables', checked: false },
@@ -87,37 +86,6 @@ export default {
 					return state;
 			}
 		}
-	}),
-
-	itemSelector: combineReducers({
-
-		title (state = '', action) {
-			switch (action.type) {
-				case actions.ITEM_SELECTOR_SET_TITLE:
-					return action.value;
-				default:
-					return state;
-			}
-		},
-
-		items (state = null, action) {
-			switch (action.type) {
-				case actions.ITEM_SELECTOR_SET_ITEMS:
-					return action.value;
-				default:
-					return state;
-			}
-		},
-
-		selectedItem (state = null, action) {
-			switch (action.type) {
-				case actions.ITEM_SELECTED:
-					return action.value;
-				default:
-					return state;
-			}
-		}
-
 	}),
 
 	events: combineReducers({
@@ -377,21 +345,6 @@ export const initialState = {
 		scrollWheelZoom: false,
 		doubleClickZoom: false,
 		boxZoom: false
-	},
-
-	itemSelector: {
-		title: 'Select a tileset',
-		items: [
-			{ "id": 1, "name": "Toner" },
-			{ "id": 2, "name": "Toner Background" },
-			{ "id": 3, "name": "Toner Lite" },
-			{ "id": 4, "name": "Terrain" },
-			{ "id": 5, "name": "Terrain Background" },
-			{ "id": 6, "name": "Watercolor" },
-			{ "id": 7, "name": "Satellite" },
-			{ "id": 8, "name": "Positron" },
-			{ "id": 9, "name": "Dark Matter" }
-		]
 	},
 
 	events: {

--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -18,34 +18,10 @@ class About extends React.Component {
 
 	componentWillMount () {
 		this.setState({});
-		var urlMode = this.props.params.mode;
-		var appMode = this.props.store.getState().mode;
-
-		if (urlMode) {
-			this.props.actions.modeChanged(urlMode);
-		} else {
-			this.updateModeUrl(appMode);
-		}
 
 		this.props.actions.mapLayersPickerProjectsChange(false);
 
 		this.onStateChange();
-	}
-
-	componentDidMount () {
-		//
-	}
-
-	componentWillUpdate (nextProps, nextState) {
-		const urlMode = this.state.mode;
-		const appMode = nextProps.store.getState().mode;
-		if (urlMode !== appMode) {
-			this.updateModeUrl(appMode);
-		}
-	}
-
-	componentDidUpdate () {
-		//
 	}
 
 	componentWillUnmount () {
@@ -55,10 +31,6 @@ class About extends React.Component {
 	onStateChange () {
 		let storeState = this.props.store.getState();
 		this.setState(storeState);
-	}
-
-	updateModeUrl (mode) {
-		this.props.router.push(`/about/${mode}`);
 	}
 
 	renderMapView () {
@@ -106,7 +78,7 @@ class About extends React.Component {
 	render () {
 		return (
 			<div id='about'>
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ this.props.params.mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -13,7 +13,6 @@ import LeafletMap from '../components/LeafletMap';
 
 // config
 import tileLayers from '../../static/tileLayers.json';
-import sassVars from '../../scss/variables.json';
 
 // main app container
 class App extends React.Component {
@@ -21,30 +20,14 @@ class App extends React.Component {
 	constructor (props) {
 		super(props);
 		// bind event handlers
-		this.onWindowResize = debounce(this.onWindowResize.bind(this), 250);
-		this.onMapMoved = this.onMapMoved.bind(this);
 		this.onAppStateChange = this.onAppStateChange.bind(this);
 		// subscribe for future state changes
 		props.store.subscribe(this.onAppStateChange);
 	}
 
 	componentWillMount () {
-		this.computeComponentDimensions();
 		// set up initial state
 		this.onAppStateChange();
-	}
-
-	componentDidMount () {
-		window.addEventListener('resize', this.onWindowResize);
-	}
-
-	componentWillUnmount () {
-		window.removeEventListener('resize', this.onWindowResize);
-	}
-
-	shouldComponentUpdate (nextProps, nextState) {
-		// Do not re-render if the state change was just map state.
-		return !this.mapHashUpdated;
 	}
 
 	componentWillUpdate (nextProps, nextState) {
@@ -79,47 +62,20 @@ class App extends React.Component {
 		this.setState(componentState);
 	}
 
-	onMapMoved (event) {
-		if (event && event.target && this.state.map.bounds && this.refs.leafletMap) {
-			/*
-			this.props.actions.mapMoved({
-				zoom: event.target.getZoom(),
-				// center: event.target.getCenter(),
-				bounds: event.target.getBounds()
-			});
-			*/
-
-			// maintain map bounds when map container resizes
-			let map = this.refs.leafletMap.getLeafletElement(),
-				currentZoom = map.getZoom(),
-				newZoom = map.getBoundsZoom(this.state.map.bounds);
-
-			if (currentZoom != newZoom) {
-				this.refs.leafletMap.getLeafletElement().fitBounds(this.state.map.bounds);
-			}
-		}
-	}
-
-	onWindowResize (event) {
-		this.computeComponentDimensions();
-	}
-
-	computeComponentDimensions () {
-		// This state is needed to render, but since it's not something that could be serialized
-		// and used to rehydrate the application on init, it exists outside of the application store.
-	}
-
 	render () {
+		// pass props down to route view
+		let childrenWithProps = React.Children.map(this.props.children, child => React.cloneElement(child, ...this.props));
+
 		return (
 			<div>
-				<MapPageToggle modeChanged={this.props.actions.modeChanged} mode={this.state.mode} />
-				<div className={'background-container' + (this.state.mode === 'map' ? '' : ' blurred')}>
-					<LeafletMap {...this.props} />
+				<MapPageToggle modeChanged={ this.props.actions.modeChanged } mode={ this.state.mode } />
+				<div className={ 'background-container' + (this.state.mode === 'map' ? '' : ' blurred') }>
+					<LeafletMap { ...this.props } />
 				</div>
 				<Header { ...this.state.header } />
 
 				<div ref='contentContainer' className='content-container'>
-					{ this.props.children }
+					{ childrenWithProps }
 					{ this.state.showFooter? <Footer /> : null }
 				</div>
 			</div>

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -68,7 +68,8 @@ class App extends React.Component {
 
 		return (
 			<div>
-				<MapPageToggle modeChanged={ this.props.actions.modeChanged } mode={ this.state.mode } />
+				{/* <MapPageToggle modeChanged={ this.props.actions.modeChanged } mode={ this.state.mode } /> */}
+				<MapPageToggle currentLocation={ this.props.location } mode={ this.state.mode } />
 				<div className={ 'background-container' + (this.state.mode === 'map' ? '' : ' blurred') }>
 					<LeafletMap { ...this.props } />
 				</div>

--- a/src/views/App.jsx
+++ b/src/views/App.jsx
@@ -33,11 +33,12 @@ class App extends React.Component {
 	componentWillUpdate (nextProps, nextState) {
 		let contentContainer = this.refs.contentContainer;
 		let footer = this.refs.footer;
+		let mode = nextProps.params.mode || 'page';
 
-		if (nextState.mode === 'map' && !contentContainer.classList.contains('map-view-enabled')) {
+		if (mode === 'map' && !contentContainer.classList.contains('map-view-enabled')) {
 			contentContainer.classList.add('map-view-enabled');
 			this.setState({ showFooter: false });
-		} else if (nextState.mode === 'page' && contentContainer.classList.contains('map-view-enabled')) {
+		} else if (mode === 'page' && contentContainer.classList.contains('map-view-enabled')) {
 			contentContainer.classList.remove('map-view-enabled');
 			this.setState({ showFooter: true });
 		}
@@ -56,8 +57,11 @@ class App extends React.Component {
 		if (storeState.map) {
 			componentState.map = Object.assign({}, storeState.map);
 		}
-		componentState.mode = storeState.mode;
-		componentState.showFooter = this.props.store.getState().mode === 'page';
+
+		let mode = this.props.params.mode || 'page';
+		componentState.mode = mode;
+		componentState.showFooter = mode === 'page';
+
 		// Call `setState()` with the updated data, which causes a re-`render()`
 		this.setState(componentState);
 	}
@@ -65,12 +69,12 @@ class App extends React.Component {
 	render () {
 		// pass props down to route view
 		let childrenWithProps = React.Children.map(this.props.children, child => React.cloneElement(child, ...this.props));
+		let mode = this.props.params.mode || 'page';
 
 		return (
 			<div>
-				{/* <MapPageToggle modeChanged={ this.props.actions.modeChanged } mode={ this.state.mode } /> */}
-				<MapPageToggle currentLocation={ this.props.location } mode={ this.state.mode } />
-				<div className={ 'background-container' + (this.state.mode === 'map' ? '' : ' blurred') }>
+			<MapPageToggle currentLocation={ this.props.location } mode={ mode } />
+				<div className={ 'background-container' + (mode === 'map' ? '' : ' blurred') }>
 					<LeafletMap { ...this.props } />
 				</div>
 				<Header { ...this.state.header } />

--- a/src/views/Events.jsx
+++ b/src/views/Events.jsx
@@ -29,15 +29,6 @@ class Events extends React.Component {
 	}
 
 	componentWillMount () {
-		var urlMode = this.props.params.mode;
-		var appMode = this.props.store.getState().mode;
-
-		if (urlMode) {
-			this.props.actions.modeChanged(urlMode);
-		} else {
-			this.updateModeUrl(appMode);
-		}
-
 		this.props.actions.mapLayersPickerProjectsChange(false);
 
 		this.onStateChange();
@@ -53,13 +44,6 @@ class Events extends React.Component {
 	}
 
 	componentWillUpdate(nextProps, nextState) {
-		var urlMode = nextProps.params.mode;
-		var appMode = nextProps.store.getState().mode;
-
-		if (urlMode !== appMode) {
-			this.updateModeUrl(appMode);
-		}
-
 		if (nextState.events.data.items.length !== this.state.events.data.items.length) {
 			this.updateFilterOptions(nextState.events);
 		}
@@ -71,10 +55,6 @@ class Events extends React.Component {
 
 	componentWillUnmount () {
 		this.unsubscribeStateChange();
-	}
-
-	updateModeUrl (mode) {
-		this.props.router.push(`/events/${mode}`);
 	}
 
 	onStateChange () {
@@ -101,7 +81,7 @@ class Events extends React.Component {
 	render () {
 		return (
 			<div id="events">
-				{ this.state.mode === 'page' ?  this.renderPageView() : this.renderMapView() }
+				{ this.props.params.mode === 'page' ?  this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -13,11 +13,6 @@ export default class Home extends React.Component {
 
 	componentWillMount () {
 		this.setState({});
-		let urlMode = this.props.params.mode;
-		let appMode = this.props.store.getState().mode;
-		if (urlMode) {
-			this.props.actions.modeChanged(urlMode);
-		}
 		
 		this.props.actions.mapLayersPickerProjectsChange(false);
 
@@ -111,9 +106,10 @@ export default class Home extends React.Component {
 	}
 
 	render () {
+		let mode = this.props.params.mode || 'page';
 		return (
 			<div id='home'>
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Projects.jsx
+++ b/src/views/Projects.jsx
@@ -1,59 +1,72 @@
 import * as React from 'react';
 import { withRouter } from 'react-router';
+import { get } from 'lodash';
+import slug from 'slug';
 
 import MapLayersPicker from '../components/MapLayersPicker';
 import MapOverlay from '../components/MapOverlay';
 import PageHeader from '../components/PageHeader';
-
-import slug from 'slug';
-
 import * as tileLayers from '../../static/tileLayers.json';
 import { vizJSON } from '../models/common.js';
 
 class Projects extends React.Component {
+	static miniMapConfig = [
+		{
+			id: 'mb',
+			title: 'Mission Bay/ Mission Rock'
+		},
+		{
+			id: 'p70',
+			title: 'Pier 70/Central Waterfront'
+		},
+		{
+			id: 'ib',
+			title: 'India Basin'
+		},
+		{
+			id: 'sc',
+			title: 'Shipyard Candlestick'
+		}
+	];
 
 	constructor (props) {
 		super(props);
 
-		this.onStateChange = this.onStateChange.bind(this);
-		this.unsubscribeStateChange = props.store.subscribe(this.onStateChange);
+		this.miniMaps = null;
 	}
 
 	componentWillMount () {
-		var urlMode = this.props.params.mode;
-		var appMode = this.props.store.getState().mode;
-
-		if (urlMode) {
-			this.props.actions.modeChanged(urlMode);
-		} else {
-			this.updateModeUrl(appMode);
-		}
+		const storeState = this.props.store.getState(),
+			geodata = get(storeState.geodata, 'zones.geojson'),
+			projects = get(storeState.projects, 'data.items');
 
 		this.props.actions.mapLayersPickerProjectsChange(true);
 
-		this.onStateChange();
-
-		if (!this.props.store.getState().geodata.zones.geojson.features) {
+		if (!geodata || !geodata.features) {
 			this.props.actions.fetchZoneGeoData();
 		}
 
-		if (!this.props.store.getState().projects.data.items.length) {
+		if (!projects || !projects.length) {
 			this.props.actions.fetchProjectsData();
 		}
-
-		this.setState({
-			maps: []
-		});
 	}
 
 	componentDidMount () {
-		// if we already have the zone data...
-		if (this.state.geodata.zones.geojson) {
-			this.createMiniMaps(this.state.geodata.zones.geojson);
-		}
+		this.createMiniMaps(get(this.props.store.getState().geodata, 'zones.geojson'));
 	}
 
-	componentWillUpdate(nextProps, nextState) {
+	componentWillUpdate (nextProps, nextState) {
+		const storeState = nextProps.store.getState(),
+			{ mode } = nextProps.store.getState(),
+			geodata = get(storeState.geodata, 'zones.geojson');
+
+		if (mode === 'page') {
+			this.createMiniMaps(geodata);
+		} else {
+			this.destroyMaps();
+		}
+
+		/*
 		var urlMode = nextProps.params.mode;
 		var appMode = nextProps.store.getState().mode;
 
@@ -64,15 +77,17 @@ class Projects extends React.Component {
 			}
 			this.updateModeUrl(appMode);
 		}
-		if (nextProps.store.getState().geodata.zones !== this.state.geodata.zones) {
-			// console.log('getting zone data');
-		}
+		*/
 	}
-
+	/*
 	componentDidUpdate (prevProps, prevState) {
 		let prevAppMode = prevState.mode;
-		let appMode = this.props.store.getState().mode;
-		if (prevState.geodata.zones !== this.state.geodata.zones) {
+
+		const storeState = this.props.store.getState(),
+			geodata = get(storeState.geodata, 'zones.geojson'),
+			appMode = storeState.mode;
+
+		if (geodata) {
 			this.createMiniMaps(this.state.geodata.zones.geojson);
 		}
 		if (prevAppMode === 'map' && appMode === 'page' && !this.state.maps.length) {
@@ -81,36 +96,21 @@ class Projects extends React.Component {
 			this.createMiniMaps(this.state.geodata.zones.geojson);
 		}
 	}
+	*/
 
-	componentWillUnmount () {
-		this.unsubscribeStateChange();
-	}
+	destroyMaps () {
+		if (!this.miniMaps) return;
 
-	onStateChange () {
-		let storeState = this.props.store.getState();
-		this.setState(storeState);
-	}
-
-	updateModeUrl (mode) {
-		this.props.router.push(`/projects/${mode}`);
-	}
-
-	destroyMaps() {
-		this.state.maps.forEach(map => {
-			map.remove();
-		});
-
-		this.setState({
-			maps: []
-		});
+		if (this.miniMaps.length) {
+			this.miniMaps.forEach(map => map.remove());
+		}
+		this.miniMaps = null;
 	}
 
 	onLearnMoreClick (mapId, e) {
-		let zoneTitleSlug = '';
-		let zoneId = this.state.geodata.zones.geojson.features.filter(feature => {
-			return feature.properties.map_id === mapId;
-		});
-		zoneId = zoneId[0].properties.map_id;
+		let geodata = get(this.props.store.getState().geodata, 'zones.geojson'),
+			zoneTitleSlug = '',
+			zoneId = geodata.features.find(feature => feature.properties.map_id === mapId).properties.map_id;
 
 		if (zoneId === 'mb') {
 			zoneTitleSlug = 'mission_bay_mission_rock';
@@ -122,37 +122,39 @@ class Projects extends React.Component {
 			zoneTitleSlug = 'shipyard_candlestick';
 		}
 
-		const mode = this.state.mode;
-		const path = `/projects/${mode}/${zoneTitleSlug}`;
+		// TODO: this should just be a <Link>, created in renderPageView()
+		let { mode } = this.props.store.getState(),
+			path = `/projects/${ mode }/${ zoneTitleSlug }`;
 		this.props.router.push(path);
 	}
 
-	createMiniMaps(zones) {
-		const refs = this.refs;
-		Object.keys(refs).forEach(key => {
-			this.renderMap(key, zones);
+	createMiniMaps (zones) {
+		if (this.miniMaps) return;
+		if (!zones || !zones.features) return;
+
+		this.miniMaps = [];
+
+		Projects.miniMapConfig.forEach(mapConfig => {
+			this.renderMap(mapConfig.id, zones);
 		});
 	}
 
-	renderMap(id, zoneFeatures) {
+	renderMap (layerId, zoneFeatures) {
 		// console.log(id, zoneFeatures);
 		// console.log('*******RENDER MINI MAP********');
-		let map;
-		let basemap = L.tileLayer(tileLayers.layers[1].url);
-		let layerId = id.split('-')[1];
-		let zoneFeaturesLayer = L.geoJson(zoneFeatures);
-		let zoneLayer = L.geoJson(zoneFeatures, {
-			filter: (feature, layer) => {
-				return feature.properties.map_id === layerId;
-			},
-			style: {
-				color: '#4DA3BC',
-				weight: 0,
-				fillColor: '#4DA3BC',
-				fillOpacity: 1,
-				clickable: false
-			}
-		});
+		let map,
+			basemap = L.tileLayer(tileLayers.layers[1].url),
+			zoneFeaturesLayer = L.geoJson(zoneFeatures),
+			zoneLayer = L.geoJson(zoneFeatures, {
+				filter: (feature, layer) => feature.properties.map_id === layerId,
+				style: {
+					color: '#4DA3BC',
+					weight: 0,
+					fillColor: '#4DA3BC',
+					fillOpacity: 1,
+					clickable: false
+				}
+			});
 
 		const options = {
 			attributionControl: false,
@@ -178,7 +180,7 @@ class Projects extends React.Component {
 			zoomControl: false
 		};
 
-		cartodb.createVis(id, vizJSON, options)
+		cartodb.createVis(`map-${ layerId }`, vizJSON, options)
 			.on('done', (vis, layers) => {
 				map = vis.getNativeMap();
 				map.addLayer(zoneLayer);
@@ -188,11 +190,8 @@ class Projects extends React.Component {
 				});
 				zoneLayer.bringToFront();
 
-				this.setState({
-					maps: [...this.state.maps, map]
-				});
-
-				// console.log(this.state.maps);
+				if (!this.miniMaps) this.miniMaps = [];
+				this.miniMaps.push(map);
 			})
 			.on('error', err => {
 				console.warn(err);
@@ -200,69 +199,57 @@ class Projects extends React.Component {
 
 	}
 
-	render () {
-		return (
-			<div id="projects">
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
-			</div>
-		);
-	}
-
 	renderPageView () {
+		console.log(">>>>> render projects page");
 		return (
 			<div className='grid-container'>
 				<PageHeader />
 				<div className='row'>
-					<div className='three columns zone-cell'>
-						<h4 className='title'>Mission Bay/ Mission Rock</h4>
-						<div ref='map-mb' id='map-mb'></div>
-						<div className='learn-more' onClick={this.onLearnMoreClick.bind(this, 'mb')}>
-							<p>Learn More</p>
-						</div>
-					</div>
-					<div className='three columns zone-cell'>
-						<h4 className='title'>Pier 70/Central Waterfront</h4>
-						<div ref='map-p70' id='map-p70'></div>
-						<div className='learn-more' onClick={this.onLearnMoreClick.bind(this, 'p70')}>
-							<p>Learn More</p>
-						</div>
-					</div>
-					<div className='three columns zone-cell'>
-						<h4 className='title'>India Basin</h4>
-						<div ref='map-ib' id='map-ib'></div>
-						<div className='learn-more' onClick={this.onLearnMoreClick.bind(this, 'ib')}>
-							<p>Learn More</p>
-						</div>
-					</div>
-					<div className='three columns zone-cell'>
-						<h4 className='title'>Shipyard Candlestick</h4>
-						<div ref='map-sc' id='map-sc'></div>
-						<div className='learn-more' onClick={this.onLearnMoreClick.bind(this, 'sc')}>
-							<p>Learn More</p>
-						</div>
-					</div>
+					{ Projects.miniMapConfig.map(mapConfig => {
+						return (
+							<div className='three columns zone-cell'>
+								<h4 className='title'>{ mapConfig.title }</h4>
+								<div id={ `map-${ mapConfig.id }` }></div>
+								<div className='learn-more' onClick={ this.onLearnMoreClick.bind(this, mapConfig.id) }>
+									<p>Learn More</p>
+								</div>
+							</div>
+						);
+					})}
 				</div>
 			</div>
 		);
 	}
 
 	renderMapView () {
+		let { mapLayersPicker } = this.props.store.getState();
+		console.log(">>>>> render projects map");
 		return (
 			<div className="projects-map-overlay">
 				<MapOverlay collapsible={ true }>
 					<MapLayersPicker
 						title='Recreation'
-						layers={ this.state.mapLayersPicker.layers }
+						layers={ mapLayersPicker.layers }
 						onLayerChange={ this.props.actions.mapLayersPickerLayerChange }
 					/>
 				</MapOverlay>
 				<MapOverlay collapsible={ true }>
 					<MapLayersPicker
 						title='Transportation'
-						layers={ this.state.mapLayersPicker.transportation }
+						layers={ mapLayersPicker.transportation }
 						onLayerChange={ this.props.actions.mapLayersPickerTransportationChange }
 					/>
 				</MapOverlay>
+			</div>
+		);
+	}
+
+	render () {
+		let { mode } = this.props.store.getState();
+		console.log(">>>>> projects mode:", mode);
+		return (
+			<div id="projects">
+				{ mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Projects.jsx
+++ b/src/views/Projects.jsx
@@ -57,7 +57,7 @@ class Projects extends React.Component {
 
 	componentWillUpdate (nextProps, nextState) {
 		const storeState = nextProps.store.getState(),
-			{ mode } = nextProps.store.getState(),
+			{ mode } = nextProps.params,
 			geodata = get(storeState.geodata, 'zones.geojson');
 
 		if (mode === 'page') {
@@ -65,38 +65,7 @@ class Projects extends React.Component {
 		} else {
 			this.destroyMaps();
 		}
-
-		/*
-		var urlMode = nextProps.params.mode;
-		var appMode = nextProps.store.getState().mode;
-
-		if (urlMode !== appMode) {
-			if (appMode === 'map') {
-				// get rid of the leaflet maps that were drawn for the page view
-				this.destroyMaps();
-			}
-			this.updateModeUrl(appMode);
-		}
-		*/
 	}
-	/*
-	componentDidUpdate (prevProps, prevState) {
-		let prevAppMode = prevState.mode;
-
-		const storeState = this.props.store.getState(),
-			geodata = get(storeState.geodata, 'zones.geojson'),
-			appMode = storeState.mode;
-
-		if (geodata) {
-			this.createMiniMaps(this.state.geodata.zones.geojson);
-		}
-		if (prevAppMode === 'map' && appMode === 'page' && !this.state.maps.length) {
-			// assumes zone geodata was already loaded while user was visiting the map view
-			if (!this.state.geodata.zones.geojson) return;
-			this.createMiniMaps(this.state.geodata.zones.geojson);
-		}
-	}
-	*/
 
 	destroyMaps () {
 		if (!this.miniMaps) return;
@@ -123,7 +92,7 @@ class Projects extends React.Component {
 		}
 
 		// TODO: this should just be a <Link>, created in renderPageView()
-		let { mode } = this.props.store.getState(),
+		let { mode } = this.props.params,
 			path = `/projects/${ mode }/${ zoneTitleSlug }`;
 		this.props.router.push(path);
 	}
@@ -245,7 +214,7 @@ class Projects extends React.Component {
 	}
 
 	render () {
-		let { mode } = this.props.store.getState();
+		let { mode } = this.props.params;
 		console.log(">>>>> projects mode:", mode);
 		return (
 			<div id="projects">

--- a/src/views/Stories.jsx
+++ b/src/views/Stories.jsx
@@ -23,15 +23,6 @@ class Stories extends React.Component {
 			categoryOptions: []
 		}});
 
-		var urlMode = this.props.params.mode;
-		var appMode = this.props.store.getState().mode;
-
-		if (urlMode) {
-			this.props.actions.modeChanged(urlMode);
-		} else {
-			this.updateModeUrl(appMode);
-		}
-
 		this.props.actions.mapLayersPickerProjectsChange(false);
 
 		this.onStateChange();
@@ -54,11 +45,6 @@ class Stories extends React.Component {
 	}
 
 	componentWillUpdate(nextProps, nextState) {
-		var urlMode = nextProps.params.mode;
-		var appMode = nextProps.store.getState().mode;
-		if (urlMode !== appMode) {
-			this.updateModeUrl(appMode);
-		}
 		if (nextState.stories.data.items.length !== this.state.stories.data.items.length) {
 			this.updateFilterOptions(nextState.stories);
 		}
@@ -70,10 +56,6 @@ class Stories extends React.Component {
 
 	componentWillUnmount () {
 		this.unsubscribeStateChange();
-	}
-
-	updateModeUrl (mode) {
-		this.props.router.push(`/stories/${mode}`);
 	}
 
 	onStateChange () {
@@ -89,8 +71,8 @@ class Stories extends React.Component {
 	}
 
 	viewStory (title, id) {
-		const mode = this.state.mode;
-		const path = `/stories/${mode}/${title}?id=${id}`;
+		const { mode } = this.props.params;
+		const path = `/stories/${ mode }/${ title }?id=${ id }`;
 		this.props.actions.updateSelectedStory({ title, id });
 		this.props.router.push(path);
 	}
@@ -107,7 +89,7 @@ class Stories extends React.Component {
 	render () {
 		return (
 			<div id="stories">
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ this.props.params.mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Story.jsx
+++ b/src/views/Story.jsx
@@ -26,15 +26,9 @@ class Story extends React.Component {
 	}
 
 	componentWillUpdate (nextProps, nextState) {
-		var urlMode = this.state.mode;
-		var appMode = nextProps.store.getState().mode;
 		var storyTitle = this.props.params.title || nextProps.store.getState().stories.selectedStory.title;
-		let { query } = this.props.location;
-		var id = query && query.id ? +query.id : null;
-		// for when the app loads with the URL of a specific story
-		if (urlMode !== appMode) {
-			this.updateModeUrl(appMode, storyTitle, id);
-		}
+		// let { query } = this.props.location;
+		// var id = query && query.id ? +query.id : null;
 		// for when the app loads with the URL of a specific story
 		if (this.state.stories.data.items !== nextState.stories.data.items &&
 			!this.props.store.getState().stories.selectedStory) {
@@ -53,25 +47,10 @@ class Story extends React.Component {
 		});
 	}
 
-	updateModeUrl (mode, title, id) {
-		if (mode && title && id) {
-			this.props.router.push(`/stories/${mode}/${title}?id=${id}`);
-		} else if (mode && !title || mode && !id) {
-			this.props.router.push(`/stories/${mode}`);
-		} else {
-			this.props.router.push('*');
-		}
-	}
-
 	componentWillMount (){
 		// console.log(this.props.location);
 		if (!this.props.store.getState().stories.data.items.length) {
 			this.props.actions.fetchStoriesData();
-		}
-		let urlMode = this.props.params.mode;
-		let appMode = this.props.store.getState().mode;
-		if (urlMode !== appMode) {
-			this.props.actions.modeChanged(urlMode);
 		}
 		this.onStateChange();
 	}
@@ -141,7 +120,7 @@ class Story extends React.Component {
 	render () {
 		return (
 			<div id="story" className='grid-container'>
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ this.props.params.mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Story.jsx
+++ b/src/views/Story.jsx
@@ -27,8 +27,8 @@ class Story extends React.Component {
 
 	componentWillUpdate (nextProps, nextState) {
 		var storyTitle = this.props.params.title || nextProps.store.getState().stories.selectedStory.title;
-		// let { query } = this.props.location;
-		// var id = query && query.id ? +query.id : null;
+		let { query } = this.props.location;
+		var id = query && query.id ? +query.id : null;
 		// for when the app loads with the URL of a specific story
 		if (this.state.stories.data.items !== nextState.stories.data.items &&
 			!this.props.store.getState().stories.selectedStory) {

--- a/src/views/Zone.jsx
+++ b/src/views/Zone.jsx
@@ -129,33 +129,12 @@ class Zone extends Component {
 		);
 	}
 
-	renderMapView () {
-		console.log(">>>>> render zone map");
-		return (
-			<div className='stories-map-overlay'>
-				<MapOverlay collapsible={ true }>
-					<MapLayersPicker
-						title='Recreation'
-						layers={ this.state.mapLayersPicker.layers }
-						onLayerChange={ this.props.actions.mapLayersPickerLayerChange }
-					/>
-				</MapOverlay>
-				<MapOverlay collapsible={ true }>
-					<MapLayersPicker
-						title='Transportation'
-						layers={ this.state.mapLayersPicker.transportation }
-						onLayerChange={ this.props.actions.mapLayersPickerTransportationChange }
-					/>
-				</MapOverlay>
-			</div>
-		);
-	}
-
 	render() {
 		console.log(">>>>> zone mode:", this.props.params.mode);
+		// map view is always handled by Projects.jsx, not Zone.jsx
 		return (
 			<div id='zone'>
-				{ this.props.params.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ this.renderPageView() }
 			</div>
 		);
 	}

--- a/src/views/Zone.jsx
+++ b/src/views/Zone.jsx
@@ -19,11 +19,6 @@ class Zone extends Component {
 		if (!this.props.store.getState().projects.data.items.length) {
 			this.props.actions.fetchProjectsData();
 		}
-		let urlMode = this.props.params.mode;
-		let appMode = this.props.store.getState().mode;
-		if (urlMode !== appMode) {
-			this.props.actions.modeChanged(urlMode);
-		}
 		this.onStateChange();
 	}
 
@@ -32,13 +27,7 @@ class Zone extends Component {
 	}
 
 	componentWillUpdate(nextProps, nextState) {
-		const urlMode = nextProps.params.mode;
-		const appMode = nextProps.store.getState().mode;
-		// console.log(urlMode, appMode);
 		const zoneTitle = this.props.params.zone;
-		if (urlMode !== appMode) {
-			this.updateModeUrl(appMode, zoneTitle);
-		}
 		if (nextState.projects !== this.state.projects) {
 			console.log('we got projects now');
 		}
@@ -55,10 +44,6 @@ class Zone extends Component {
 	onStateChange () {
 		let storeState = this.props.store.getState();
 		this.setState(storeState);
-	}
-
-	updateModeUrl (mode, zoneTitle) {
-		this.props.router.push(`/projects/${mode}/${zoneTitle}`);
 	}
 
 	mapProjectZone(BGWZone) {
@@ -167,10 +152,10 @@ class Zone extends Component {
 	}
 
 	render() {
-		console.log(">>>>> zone mode:", this.state.mode);
+		console.log(">>>>> zone mode:", this.props.params.mode);
 		return (
 			<div id='zone'>
-				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }
+				{ this.props.params.mode === 'page' ? this.renderPageView() : this.renderMapView() }
 			</div>
 		);
 	}

--- a/src/views/Zone.jsx
+++ b/src/views/Zone.jsx
@@ -110,6 +110,7 @@ class Zone extends Component {
 	}
 
 	renderPageView () {
+		console.log(">>>>> render zone page");
 		let zoneTitle = this.props.params.zone.split('_').join(' ');
 		const about = `Some placeholder text about ${zoneTitle}....`;
 
@@ -144,6 +145,7 @@ class Zone extends Component {
 	}
 
 	renderMapView () {
+		console.log(">>>>> render zone map");
 		return (
 			<div className='stories-map-overlay'>
 				<MapOverlay collapsible={ true }>
@@ -165,6 +167,7 @@ class Zone extends Component {
 	}
 
 	render() {
+		console.log(">>>>> zone mode:", this.state.mode);
 		return (
 			<div id='zone'>
 				{ this.state.mode === 'page' ? this.renderPageView() : this.renderMapView() }


### PR DESCRIPTION
Views were messing with history state based on what was in the URL. History state should be solely the domain of the router and the URL (e.g. via `<Link>`s/`<a href>`s, and was breaking forward/backward navigation. It was also making it super hard to understand the state of the application at any moment.

Now, routes are set up (in main.jsx) to do the routing, and all the `router.push` (aka `history.push`) calls in the views are removed. Also, application `mode` (map or page view) is now stored only in the URL, and not duplicated in the store.

More changes happen in this PR:
- `App.jsx` passes props down into the page views specified in the routes, so they have access to the store and actions (actually, I think this is unnecessary due to [main.jsx::createReduxComponent](https://github.com/stamen/bluegreenway/blob/master/src/main.jsx#L55), but it's in there now);
- `Projects.jsx` no longer responds to store changes `setState()`s, reducing `render()` calls and generally cleaning up application flow;
- `Projects.jsx` and `Zone.jsx` both rendered their own map view, depending on whether or not there was a zone in the URL. It's the same view and should be rendered only in one place. That place is now `Projects.jsx`.

One thing this PR does not due, due to time constraints, is to refactor other views as was done in `Projects.jsx` -- they're still responding to store changes and `render()`ing more frequently than they should. I'll refactor these as I touch those files for other issues.

Fixes #79 and makes life a whole lot easier for the rest of this project.
